### PR TITLE
Emphasize Docker memory & CPU prerequisites in README

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -21,10 +21,6 @@ RUN git clone https://github.com/pelias/api.git /code/pelias/api
 # change working dir
 WORKDIR /code/pelias/api
 
-# switch to custom branch
-# @todo: use master branch once merged
-RUN git checkout 'libpostal_1.0.0'
-
 # npm apt dependencies
 # note: this is done in one command in order to keep down the size of intermediate containers
 RUN apt-get update && apt-get install -y python && rm -rf /var/lib/apt/lists/*

--- a/readme.md
+++ b/readme.md
@@ -1,14 +1,34 @@
 
 dockerfiles for pelias services
 
-### prerequisites
-
+### Prerequisites
+1. Minimum Docker and Docker-Compose version
 ```
 docker: min version xxx
 docker-compose: min version xxx
 ```
 
-## getting up and running
+2. In Docker > Preferences > Advanced, set the CPU to `4` and memory to `12 GB`.
+
+3. A `/tmp/data` directory for storing downloaded datasets. Set `DATA_DIR` to the folder's path in `.env` file.
+
+#### Create a Directory for Your Data
+
+Each of the containers will be able to access this directory internally as `/data`, source data downloaded by the containers will be stored here.
+
+> note: the data can be fairly large, make sure you have at minimum ~15GB free space available on this volume
+
+```bash
+mkdir -p /tmp/data
+```
+
+if you wish to change the location of your data directory you can replace all instances of the path in your `docker-compose.yml`.
+
+each importer and service has a range of different options, detailed installation and configuration instructions can be found here: https://github.com/pelias/pelias/blob/master/INSTALL.md
+
+for an up-to-date references of supported options you can also view the README files contained in each repository on Github.
+
+## Getting Up and Running
 
 the following command will build all the images and containers required:
 
@@ -36,23 +56,7 @@ pelias_schema          /bin/bash                 Exit 0
 pelias_whosonfirst     /bin/bash                 Exit 0
 ```
 
-#### create a directory for your data
-
-each of the containers will be able to access this directory internally as `/data`, source data downloaded by the containers will be stored here.
-
-> note: the data can be fairly large, make sure you have at minimum ~15GB free space available on this volume
-
-```bash
-mkdir -p /tmp/data
-```
-
-if you wish to change the location of your data directory you can replace all instances of the path in your `docker-compose.yml`.
-
-each importer and service has a range of different options, detailed installation and configuration instructions can be found here: https://github.com/pelias/pelias/blob/master/INSTALL.md
-
-for an up-to-date references of supported options you can also view the README files contained in each repository on Github.
-
-#### setting up elasticsearch
+## Setting Up Elasticsearch
 
 the following command will install the pelias schema in elasticsearch:
 
@@ -62,17 +66,17 @@ docker-compose run --rm schema bash -c 'node scripts/create_index.js'
 
 you can confirm this worked correctly by visiting http://localhost:9200/pelias/_mapping
 
-#### checking the api service is running
+#### Checking that API Service is Running
 
 the api service should already be running on port 4000.
 
 you can confirm this worked correctly by visiting http://localhost:4000/v1/search?text=example
 
-## importing whosonfirst
+## Importing Whosonfirst
 
 > note: this guide only covers importing the admin areas (like cities, countries etc.)
 
-#### downloading the data
+#### Downloading the Data
 
 ensure the data directory exists:
 
@@ -86,7 +90,7 @@ download the data:
 docker-compose run --rm whosonfirst bash -c 'node download_data.js'
 ```
 
-#### importing the data
+#### Importing the Data
 
 import whosonfirst data:
 
@@ -94,9 +98,9 @@ import whosonfirst data:
 docker-compose run --rm whosonfirst bash -c 'npm start'
 ```
 
-## importing openstreetmap
+## Importing OpenStreetMap
 
-#### downloading the data
+#### Downloading the Data
 
 ensure the data directory exists:
 
@@ -104,13 +108,15 @@ ensure the data directory exists:
 mkdir -p /tmp/data/openstreetmap
 ```
 
-download the data:
+Any `osm.pbf` file will work. A good source is [Metro Extracts](https://mapzen.com/data/metro-extracts/), which has major cities and custom areas. Download and place the file in the data directory above.
+
+Or, download the data (for Singapore):
 
 ```bash
 wget -qO- https://s3.amazonaws.com/metro-extracts.mapzen.com/singapore.osm.pbf > /tmp/data/openstreetmap/extract.osm.pbf
 ```
 
-#### importing the data
+#### Importing the Data
 
 import openstreetmap data:
 
@@ -118,9 +124,9 @@ import openstreetmap data:
 docker-compose run --rm openstreetmap bash -c 'npm start'
 ```
 
-## importing geonames
+## Importing Geonames
 
-#### customizing your configuration
+#### Customizing Your Configuration
 
 you can restrict the downloader to a single country by adding a `countryCode` property in your `pelias.json`:
 
@@ -133,7 +139,7 @@ you can restrict the downloader to a single country by adding a `countryCode` pr
 }
 ```
 
-#### downloading the data
+#### Downloading the Data
 
 ensure the data directory exists:
 
@@ -147,10 +153,40 @@ download the data:
 docker-compose run --rm geonames bash -c 'npm run download'
 ```
 
-#### importing the data
+#### Importing the Data
 
 import geonames data:
 
 ```bash
 docker-compose run --rm geonames bash -c 'npm start'
 ```
+## Importing Polylines
+
+#### Downloading the Data
+
+ensure the data directory exists:
+
+```bash
+mkdir -p /tmp/data/polyline
+```
+download the data:
+
+The Pelias/Polylines repo has some [polylines extracts](https://github.com/pelias/polylines#download-data). Once you have unzipped the file, specify the name of the polylines data file in your `pelias.json`
+
+```javascript
+"imports" : {
+  "polyline": {
+    ...
+    "files": ["san_francisco.polylines"]
+  }
+
+}
+```
+#### Importing the Data
+import polylines data:
+```bash
+docker-compose run --rm polylines bash -c 'PELIAS_CONFIG=/code/pelias.json npm start'
+```
+
+#### Shutting Down and Restarting
+To stop all the containers, `docker-compose down`. Restart all the containers with `docker-compose up`.


### PR DESCRIPTION
From my installation process, I needed 12 GB and 4 CPU (maybe 3 is okay but 2 is not enough). 

- Moved the section on creating folder for the data up because DATA_DIR needs to be set for the build to start.
- Added section on Polylines download and import
- Capitalized first letter of each word in headers

Part of https://github.com/pelias/pelias/issues/596