### PR TITLE
Openaddresses Importer dbclient support es@5

### DIFF
--- a/openaddresses/Dockerfile
+++ b/openaddresses/Dockerfile
@@ -10,5 +10,11 @@ WORKDIR /code/pelias/openaddresses
 # install npm dependencies
 RUN npm install
 
+# update dbclient 'elasticsearch' dependency to support es@5
+# @todo: fix and remove this
+WORKDIR /code/pelias/openaddresses/node_modules/pelias-dbclient
+RUN npm install elasticsearch@latest
+WORKDIR /code/pelias/openaddresses
+
 # run tests
 RUN npm test


### PR DESCRIPTION
Copied code from the OSM importer dockerfile. Elasticsearch-js 5 as dependency of dbclient, which is dependency of OpenAddresses importer