### PR TITLE
elasticsearch 5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
   elasticsearch:
     image: pelias/elasticsearch
     container_name: pelias_elasticsearch
-    build: elasticsearch/2.4
+    build: elasticsearch/5.2.1
     restart: always
     ports: [ "9200:9200" ]
     networks: [ "pelias" ]

--- a/elasticsearch/2.4/Dockerfile
+++ b/elasticsearch/2.4/Dockerfile
@@ -1,5 +1,0 @@
-# base image
-FROM elasticsearch:2.4
-
-# configure plugins
-RUN /usr/share/elasticsearch/bin/plugin install analysis-icu

--- a/geonames/Dockerfile
+++ b/geonames/Dockerfile
@@ -13,5 +13,11 @@ RUN npm install
 # update metadata
 RUN npm run download_metadata
 
+# update dbclient 'elasticsearch' dependency to support es@5
+# @todo: fix and remove this
+WORKDIR /code/pelias/geonames/node_modules/pelias-dbclient
+RUN npm install elasticsearch@latest
+WORKDIR /code/pelias/geonames
+
 # run tests
 RUN npm test

--- a/openaddresses/Dockerfile
+++ b/openaddresses/Dockerfile
@@ -10,5 +10,11 @@ WORKDIR /code/pelias/openaddresses
 # install npm dependencies
 RUN npm install
 
+# update dbclient 'elasticsearch' dependency to support es@5
+# @todo: fix and remove this
+WORKDIR /code/pelias/openaddresses/node_modules/pelias-dbclient
+RUN npm install elasticsearch@latest
+WORKDIR /code/pelias/openaddresses
+
 # run tests
 RUN npm test

--- a/openstreetmap/Dockerfile
+++ b/openstreetmap/Dockerfile
@@ -10,5 +10,11 @@ WORKDIR /code/pelias/openstreetmap
 # install npm dependencies
 RUN npm install
 
+# update dbclient 'elasticsearch' dependency to support es@5
+# @todo: fix and remove this
+WORKDIR /code/pelias/openstreetmap/node_modules/pelias-dbclient
+RUN npm install elasticsearch@latest
+WORKDIR /code/pelias/openstreetmap
+
 # run tests
 RUN npm test

--- a/pelias.json
+++ b/pelias.json
@@ -4,7 +4,7 @@
     "timestamp": false
   },
   "esclient": {
-    "apiVersion": "2.3",
+    "apiVersion": "5.0",
     "hosts": [{
       "env": "development",
       "protocol": "http",

--- a/polylines/Dockerfile
+++ b/polylines/Dockerfile
@@ -10,5 +10,11 @@ WORKDIR /code/pelias/polylines
 # install npm dependencies
 RUN npm install
 
+# update dbclient 'elasticsearch' dependency to support es@5
+# @todo: fix and remove this
+WORKDIR /code/pelias/polylines/node_modules/pelias-dbclient
+RUN npm install elasticsearch@latest
+WORKDIR /code/pelias/polylines
+
 # run tests
 RUN npm test

--- a/schema/Dockerfile
+++ b/schema/Dockerfile
@@ -7,6 +7,10 @@ RUN git clone https://github.com/pelias/schema.git /code/pelias/schema
 # change working dir
 WORKDIR /code/pelias/schema
 
+# switch to custom branch
+# @todo: use master branch once merged
+RUN git checkout 'es5-compat'
+
 # install npm dependencies
 RUN npm install
 

--- a/whosonfirst/Dockerfile
+++ b/whosonfirst/Dockerfile
@@ -14,5 +14,11 @@ WORKDIR /code/pelias/whosonfirst
 # install npm dependencies
 RUN npm install
 
+# update dbclient 'elasticsearch' dependency to support es@5
+# @todo: fix and remove this
+WORKDIR /code/pelias/whosonfirst/node_modules/pelias-dbclient
+RUN npm install elasticsearch@latest
+WORKDIR /code/pelias/whosonfirst
+
 # run tests
 RUN npm test


### PR DESCRIPTION
[ DO NOT MERGE ]

this is a branch with all the code required to run an elasticsearch 5 server instead of a 2.4

it's useful for testing how well the queries work with the 5.x series but is not currently the recommended version to use.

see https://github.com/pelias/pelias/issues/461#issuecomment-282107762 for more info on what work is still outstanding for a full 5.x migration 