### PR TITLE
OSX specific instructions. Specify min docker version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,10 +4,10 @@ Dockerfiles for [Pelias](https://github.com/pelias/pelias) services
 ### Prerequisites
 1. Docker version `1.10.1` or later.
 
-1. A `/tmp/data` directory for storing downloaded datasets. Set `DATA_DIR` to the folder's path in `.env` file.
+1. A directory for storing downloaded datasets. Set `DATA_DIR` to the folder's path in `.env` file.
 
 1. **OSX Only**
-  1. In Docker > Preferences > Advanced, set the CPU to `4` and memory to `12 GB`. This ensures that Docker has enough memory to run the imports and API.
+    1. In Docker > Preferences > Advanced, set the CPU to `4` and memory to `12 GB`. This ensures that Docker has enough memory to run the imports and API.
 
 #### Create a Directory for Your Data
 

--- a/readme.md
+++ b/readme.md
@@ -1,16 +1,13 @@
 
-dockerfiles for pelias services
+Dockerfiles for [Pelias](https://github.com/pelias/pelias) services
 
 ### Prerequisites
-1. Minimum Docker and Docker-Compose version
-```
-docker: min version xxx
-docker-compose: min version xxx
-```
+1. Docker version `1.10.1` or later.
 
-2. In Docker > Preferences > Advanced, set the CPU to `4` and memory to `12 GB`.
+1. A `/tmp/data` directory for storing downloaded datasets. Set `DATA_DIR` to the folder's path in `.env` file.
 
-3. A `/tmp/data` directory for storing downloaded datasets. Set `DATA_DIR` to the folder's path in `.env` file.
+1. **OSX Only**
+  1. In Docker > Preferences > Advanced, set the CPU to `4` and memory to `12 GB`. This ensures that Docker has enough memory to run the imports and API.
 
 #### Create a Directory for Your Data
 


### PR DESCRIPTION
Adjusting memory and CPU only required for OSX. Fixes https://github.com/pelias/dockerfiles/pull/1#pullrequestreview-45952104 

Linked to pelias/pelias repo at top

Part of https://github.com/pelias/pelias/issues/596