### PR TITLE
geonames: run metadata download script

### DIFF
--- a/geonames/Dockerfile
+++ b/geonames/Dockerfile
@@ -25,3 +25,6 @@ RUN npm install
 
 # run tests
 RUN npm test
+
+# download meta data
+RUN npm run download_metadata


### PR DESCRIPTION
as per https://github.com/pelias/geonames/issues/222 the `npm run download_metadata` step is required.