### PR TITLE
Upgrade to Node.js 4.8.4

### DIFF
--- a/baseimage/Dockerfile
+++ b/baseimage/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:latest
 
 # build variables
-ENV NODE_VERSION='4.4.7'
+ENV NODE_VERSION='4.8.4'
 
 # configure env
 ENV DEBIAN_FRONTEND 'noninteractive'


### PR DESCRIPTION
There was a [critical security vulnerability](https://nodejs.org/en/blog/vulnerability/july-2017-security-releases/) in all Node.js release lines a while back. It won't affect most of our images, but API in particular needs to be updated.