### PR TITLE
Change sh to bash for all data_prep scripts

### DIFF
--- a/prep_data.sh
+++ b/prep_data.sh
@@ -25,13 +25,13 @@ wait;
 
 # polylines data prep requires openstreetmap data, so wait until that's done to start this
 # but then wait to run the polylines importer process until this is finished
-#docker-compose run --rm valhalla sh ./docker_build.sh;
-docker-compose run --rm polylines sh ./docker_extract.sh;
+#docker-compose run --rm valhalla bash ./docker_build.sh;
+docker-compose run --rm polylines bash ./docker_extract.sh;
 
 docker-compose run --rm placeholder npm run extract;
 docker-compose run --rm placeholder npm run build;
 
-docker-compose run --rm interpolation sh ./docker_build.sh &
+docker-compose run --rm interpolation bash ./docker_build.sh &
 docker-compose run --rm whosonfirst npm start &
 docker-compose run --rm openaddresses npm start &
 docker-compose run --rm openstreetmap npm start &


### PR DESCRIPTION
The polylines build is currently broken because there is a `bash` command in the script but we are running it in `sh`.