### PR TITLE
Install NPM3 in baseimage

### DIFF
--- a/baseimage/Dockerfile
+++ b/baseimage/Dockerfile
@@ -35,6 +35,9 @@ RUN git clone 'https://github.com/isaacs/nave.git' /code/nave && /code/nave/nave
 # add global install dir to $NODE_PATH
 ENV NODE_PATH="/usr/local/lib/node_modules:$NODE_PATH"
 
+# update NPM
+RUN npm install -g npm@3
+
 # copy pelias config
 ADD 'pelias.json' '/code/pelias.json'
 ENV PELIAS_CONFIG '/code/pelias.json'


### PR DESCRIPTION
NPM 2, the default installed with Node.js 4, is very old and has quite a few bugs. One of them is that it does not properly forward signals, such as `SIGTERM` to its child processes.

When `docker stop` is run, Docker sends the `SIGTERM` signal to the topmost process in the Docker container. It then waits (a default of) [10 seconds](https://docs.docker.com/engine/reference/commandline/stop/) before sending `SIGKILL`.

This means, without upgrading to NPM3, our docker containers will hang for 10 seconds whenever we try to stop them.

Ideally, we will upgrade to an even newer version of NPM in the near future. NPM 4 and especially 5 are quite a bit faster and fix even more bugs.