### PR TITLE
Set HOST environment variable for API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     image: pelias/api
     container_name: pelias_api
     restart: always
-    environment: [ "PORT=4000" ]
+    environment: [ "PORT=4000", "HOST=0.0.0.0" ]
     ports: [ "4000:4000" ]
     networks: [ "pelias" ]
     volumes:


### PR DESCRIPTION
Since https://github.com/pelias/api/pull/1031 the HOST environment variable must be specified anywhere the API will be run and expects to serve traffic to non-local clients, including Docker images

Connects https://github.com/pelias/api/issues/1037