### PR TITLE
Pull Docker images from Docker Hub instead of building

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,8 +5,8 @@
 # note: the -v flag deletes ALL persistent data volumes
 docker-compose down || true;
 
-# rebuild the images
-docker-compose build;
+# pull images from docker hub. Building them manually is not suggested in normal cases
+docker-compose pull;
 
 time sh ./prep_data.sh;
 

--- a/run_services.sh
+++ b/run_services.sh
@@ -18,6 +18,6 @@ fi
 # note: the -d flag will background the logs
 docker-compose up -d interpolation;
 docker-compose up -d placeholder;
-docker-compose up -d pip;
+docker-compose up -d pip-service;
 docker-compose up -d api;
 


### PR DESCRIPTION
Under normal circumstances, we don't want users to be building images,
since it takes a long time, and we have them built automatically anyways.
They can be built individually within each repository if really needed.

Especially now that we don't have Dockerfiles in this repo, building is not helpful.