### PR TITLE
[DO NOT MERGE] Upgrade Docker Baseimage to Node.js 8.10.0

### DIFF
--- a/baseimage/Dockerfile
+++ b/baseimage/Dockerfile
@@ -27,7 +27,7 @@ RUN git config --global 'user.email' 'pelias.team@gmail.com'
 RUN git config --global 'user.name' 'Pelias Docker'
 
 # install nodejs
-ENV NODE_VERSION='6.13.0'
+ENV NODE_VERSION='8.10.0'
 RUN git clone 'https://github.com/isaacs/nave.git' /code/nave && /code/nave/nave.sh 'usemain' "${NODE_VERSION}" && rm -rf /code/nave
 
 # add global install dir to $NODE_PATH


### PR DESCRIPTION
As we move towards [support for Node.js 8](https://github.com/pelias/pelias/issues/612), one of the biggest steps is changing the version in the Dockerfiles. This is all it will take in this repo, but we'll want to test things out before merging. Additionally, we don't currently have a great way to enable this for only master/staging branches. However, rebuilding the baseimages manually and testing API and PIP (so far) on my machine has worked well.

Before we can merge this, we have to ensure that all our code up to the production branch is ready for Node.js. As far as I know the only thing that requires is merging https://github.com/pelias/whosonfirst/pull/310, and then ensuring all our services in production are using at least [whosonfirst 2.21.1](https://github.com/pelias/whosonfirst/releases/tag/v2.21.1) and [wof-admin-lookup 4.3.2](https://github.com/pelias/wof-admin-lookup/releases/tag/v4.3.2)