### PR TITLE
Enable the Libpostal Service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     volumes:
       - "./pelias.json:/code/pelias.json"
   api:
-    image: pelias/api
+    image: pelias/api:staging
     container_name: pelias_api
     restart: always
     environment: [ "PORT=4000" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
     volumes:
       - "./pelias.json:/code/pelias.json"
   api:
-    depends_on: [ "libpostal_baseimage" ]
     image: pelias/api
     container_name: pelias_api
     restart: always
@@ -26,7 +25,6 @@ services:
     networks: [ "pelias" ]
     volumes:
       - "./pelias.json:/code/pelias.json"
-      - "libpostaldata:/usr/share/libpostal"
   libpostal:
     image: pelias/go-whosonfirst-libpostal
     container_name: pelias_libpostal

--- a/pelias.json
+++ b/pelias.json
@@ -23,6 +23,9 @@
       "placeholder": {
         "url": "http://placeholder:4100"
       },
+      "libpostal": {
+        "url": "http://libpostal:8080"
+      },
       "pip": {
         "url": "http://pip-service:4200"
       },

--- a/run_services.sh
+++ b/run_services.sh
@@ -22,5 +22,6 @@ fi
 docker-compose up -d interpolation;
 docker-compose up -d placeholder;
 docker-compose up -d pip-service;
+docker-compose up -d libpostal;
 docker-compose up -d api;
 


### PR DESCRIPTION
As mentioned in https://github.com/pelias/api/pull/1060 and https://github.com/pelias/api/issues/1072, we have started converting Libpostal to its own service, rather than loading it into memory in the API service. This PR adds support for that in the dockerfiles.

It's ready to go immediately, although for now it will have to use an API docker image built off of the master branch.

I'd like to merge this _before_ we merge the API changes for the libpostal service to the production branch, to ensure there's a seamless transition. Then we should go back and update the docker-compose.yml file to point to the production Docker images.