### PR TITLE
Use Node.js 6.13.0

### DIFF
--- a/baseimage/Dockerfile
+++ b/baseimage/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:latest
 
 # build variables
-ENV NODE_VERSION='4.8.4'
+ENV NODE_VERSION='6.13.0'
 
 # configure env
 ENV DEBIAN_FRONTEND 'noninteractive'


### PR DESCRIPTION
This allows us to immediately start deprecating Node.js 4

Connects https://github.com/pelias/pelias/issues/693