### PR TITLE
Remove NPM install, speed up build

### DIFF
--- a/baseimage/Dockerfile
+++ b/baseimage/Dockerfile
@@ -1,9 +1,6 @@
 # base image
 FROM ubuntu:latest
 
-# build variables
-ENV NODE_VERSION='6.13.0'
-
 # configure env
 ENV DEBIAN_FRONTEND 'noninteractive'
 
@@ -30,6 +27,7 @@ RUN git config --global 'user.email' 'pelias@mapzen.com'
 RUN git config --global 'user.name' 'Pelias Docker'
 
 # install nodejs
+ENV NODE_VERSION='6.13.0'
 RUN git clone 'https://github.com/isaacs/nave.git' /code/nave && /code/nave/nave.sh 'usemain' "${NODE_VERSION}" && rm -rf /code/nave
 
 # add global install dir to $NODE_PATH

--- a/baseimage/Dockerfile
+++ b/baseimage/Dockerfile
@@ -35,9 +35,6 @@ RUN git clone 'https://github.com/isaacs/nave.git' /code/nave && /code/nave/nave
 # add global install dir to $NODE_PATH
 ENV NODE_PATH="/usr/local/lib/node_modules:$NODE_PATH"
 
-# update NPM
-RUN npm install -g npm@3
-
 # copy pelias config
 ADD 'pelias.json' '/code/pelias.json'
 ENV PELIAS_CONFIG '/code/pelias.json'


### PR DESCRIPTION
Now that we're on a modern version of Node.js, we don't need to explicitly install NPM (in fact it causes problems). From now on with Node.js 6 and 8, we'll be happy to use the bundled NPM.

I also moved the NODE_VERSION definition down to lower in the Dockerfile, this speeds up repeat builds quite a bit if the version changes.

Once this is merged and the baseimage is pushed, we can basically consider https://github.com/pelias/pelias/issues/693 (deprecation of Node.js 4) started. 