### PR TITLE
Update OSM download to use Nextzen S3 bucket

### DIFF
--- a/pelias.json
+++ b/pelias.json
@@ -42,7 +42,7 @@
     "openstreetmap": {
       "download": [
         {
-          "sourceURL": "https://s3.amazonaws.com/metro-extracts.mapzen.com/portland_oregon.osm.pbf"
+          "sourceURL": "https://s3.amazonaws.com/metro-extracts.nextzen.org/portland_oregon.osm.pbf"
         }
       ],
       "leveldbpath": "/tmp",


### PR DESCRIPTION
The Mapzen Metro extracts have disappeared with the Mapzen shutdown.
Fortunately, AWS is generously hosting them going forward, we just have
to update the links.

Connects https://github.com/pelias/pelias/issues/703