### PR TITLE
Add lipbostal service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,12 @@ services:
     volumes:
       - "./pelias.json:/code/pelias.json"
       - "libpostaldata:/usr/share/libpostal"
+  libpostal:
+    image: pelias/go-whosonfirst-libpostal
+    container_name: pelias_libpostal
+    restart: always
+    ports: [ "8080:8080" ]
+    networks: [ "pelias" ]
   placeholder:
     depends_on: [ "baseimage" ]
     image: pelias/placeholder


### PR DESCRIPTION
The Pelias API has now been modified to expect libpostal to live as a separate HTTP service rather than being included in memory.

This PR adds the libpostal service to `docker-compose.yml` but doesn't change anything else. The current (as of 2018/3/19) `production` version of Pelias API does not yet use the libpostal service. It's convenient to have this merged so that we can start the process of switching over, though.

Connects https://github.com/pelias/dockerfiles/pull/42