### PR TITLE
Run import mostly in serial

### DIFF
--- a/prep_data.sh
+++ b/prep_data.sh
@@ -35,9 +35,9 @@ docker-compose run --rm placeholder npm run extract;
 docker-compose run --rm placeholder npm run build;
 
 docker-compose run --rm interpolation bash ./docker_build.sh &
-docker-compose run --rm whosonfirst npm start &
-docker-compose run --rm openaddresses npm start &
-docker-compose run --rm openstreetmap npm start &
-docker-compose run --rm polylines npm start &
+docker-compose run --rm whosonfirst npm start
+docker-compose run --rm openaddresses npm start
+docker-compose run --rm openstreetmap npm start
+docker-compose run --rm polylines npm start
 
 wait;

--- a/prep_data.sh
+++ b/prep_data.sh
@@ -5,10 +5,10 @@ export $(cat .env | xargs)
 
 # start elasticsearch if it's not already running
 if ! [ $(curl --output /dev/null --silent --head --fail http://localhost:9200) ]; then
-    docker-compose up -d elasticsearch;
+    docker-compose up -d elasticsearch
 
     # wait for elasticsearch to start up
-    echo 'waiting for elasticsearch service to come up';
+    echo 'waiting for elasticsearch service to come up'
     until $(curl --output /dev/null --silent --head --fail http://localhost:9200); do
       printf '.'
       sleep 2
@@ -16,7 +16,7 @@ if ! [ $(curl --output /dev/null --silent --head --fail http://localhost:9200) ]
 fi
 
 # create the index in elasticsearch before importing data
-docker-compose run --rm schema npm run create_index;
+docker-compose run --rm schema npm run create_index
 
 # download all the data to be used by imports
 docker-compose run --rm whosonfirst npm run download &
@@ -24,15 +24,15 @@ docker-compose run --rm openaddresses npm run download &
 docker-compose run --rm openstreetmap npm run download &
 docker-compose run --rm interpolation npm run download-tiger &
 
-wait;
+wait
 
 # polylines data prep requires openstreetmap data, so wait until that's done to start this
 # but then wait to run the polylines importer process until this is finished
-#docker-compose run --rm valhalla bash ./docker_build.sh;
-docker-compose run --rm polylines bash ./docker_extract.sh;
+#docker-compose run --rm valhalla bash ./docker_build.sh
+docker-compose run --rm polylines bash ./docker_extract.sh
 
-docker-compose run --rm placeholder npm run extract;
-docker-compose run --rm placeholder npm run build;
+docker-compose run --rm placeholder npm run extract
+docker-compose run --rm placeholder npm run build
 
 docker-compose run --rm interpolation bash ./docker_build.sh &
 docker-compose run --rm whosonfirst npm start
@@ -40,4 +40,4 @@ docker-compose run --rm openaddresses npm start
 docker-compose run --rm openstreetmap npm start
 docker-compose run --rm polylines npm start
 
-wait;
+wait


### PR DESCRIPTION
It's very easy for a low CPU or RAM machine to run into issues when running all the importers in parallel. 

Running out of memory can sometimes cause one of the importers to crash, and getting low on CPU risks Elasticsearch dropping indexing requests and invalidating the entire build.

In my testing, things run almost as fast in serial: because Elasticsearch is only dealing with one set of bulk index requests at a time, everything goes faster. This can probably especially help with https://github.com/pelias/dockerfiles/issues/46 and similar issues. 