### PR TITLE
Move API back to production branch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     volumes:
       - "./pelias.json:/code/pelias.json"
   api:
-    image: pelias/api:staging
+    image: pelias/api
     container_name: pelias_api
     restart: always
     environment: [ "PORT=4000" ]


### PR DESCRIPTION
Now that https://github.com/pelias/api/pull/1138 is merged, the Pelias API production images now use the Libpostal service, as described in https://github.com/pelias/api/issues/1072. In https://github.com/pelias/dockerfiles/pull/42 we said we would use the staging branch for the API in this repo until that merge happened. Now we can move back!