### PR TITLE
deprecation: deprecation notices

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,16 @@
 #!/bin/bash
+
+# deprecation notice
+2>&1 echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!';
+2>&1 echo 'This repository has been deprecated in favour of https://github.com/pelias/docker';
+2>&1 echo;
+2>&1 echo 'We strongly recommended you to migrate any code referencing this repository';
+2>&1 echo 'to use https://github.com/pelias/docker as soon as possible.'
+2>&1 echo;
+2>&1 echo 'You can find more information about why we deprecated this code along with a migration guide in the wiki:';
+2>&1 echo 'https://github.com/pelias/dockerfiles/wiki/Deprecation-Notice';
+2>&1 echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!';
+
 # bring containers down
 # note: the -v flag deletes ALL persistent data volumes
 docker-compose down || true;

--- a/example.sh
+++ b/example.sh
@@ -1,4 +1,16 @@
 #!/bin/bash
+
+# deprecation notice
+2>&1 echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!';
+2>&1 echo 'This repository has been deprecated in favour of https://github.com/pelias/docker';
+2>&1 echo;
+2>&1 echo 'We strongly recommended you to migrate any code referencing this repository';
+2>&1 echo 'to use https://github.com/pelias/docker as soon as possible.'
+2>&1 echo;
+2>&1 echo 'You can find more information about why we deprecated this code along with a migration guide in the wiki:';
+2>&1 echo 'https://github.com/pelias/dockerfiles/wiki/Deprecation-Notice';
+2>&1 echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!';
+
 export DATA_DIR='/media/black/data'
 
 function trimWofById() {

--- a/prep_data.sh
+++ b/prep_data.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# deprecation notice
+2>&1 echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!';
+2>&1 echo 'This repository has been deprecated in favour of https://github.com/pelias/docker';
+2>&1 echo;
+2>&1 echo 'We strongly recommended you to migrate any code referencing this repository';
+2>&1 echo 'to use https://github.com/pelias/docker as soon as possible.'
+2>&1 echo;
+2>&1 echo 'You can find more information about why we deprecated this code along with a migration guide in the wiki:';
+2>&1 echo 'https://github.com/pelias/dockerfiles/wiki/Deprecation-Notice';
+2>&1 echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!';
+
 # load DATA_DIR and other vars from docker-compose .env file
 export $(cat .env | xargs)
 

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,12 @@
+
+:warning: This repository has been deprecated in favour of https://github.com/pelias/docker.
+
+:warning: We strongly recommended you to migrate any code referencing this repository to use https://github.com/pelias/docker as soon as possible.
+
+:warning: You can find more information about why we deprecated this code along with a migration guide in the wiki: https://github.com/pelias/dockerfiles/wiki/Deprecation-Notice
+
+---
+
 # Pelias Dockerfiles
 
 This is a [Docker Compose](https://github.com/docker/compose#docker-compose) based demo application for running the [Pelias Geocoder](https://github.com/pelias/pelias).

--- a/run_services.sh
+++ b/run_services.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# deprecation notice
+2>&1 echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!';
+2>&1 echo 'This repository has been deprecated in favour of https://github.com/pelias/docker';
+2>&1 echo;
+2>&1 echo 'We strongly recommended you to migrate any code referencing this repository';
+2>&1 echo 'to use https://github.com/pelias/docker as soon as possible.'
+2>&1 echo;
+2>&1 echo 'You can find more information about why we deprecated this code along with a migration guide in the wiki:';
+2>&1 echo 'https://github.com/pelias/dockerfiles/wiki/Deprecation-Notice';
+2>&1 echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!';
+
 # load DATA_DIR and other vars from docker-compose .env file
 export $(cat .env | xargs)
 


### PR DESCRIPTION
this PR officially deprecates this repo, providing a deprecation notice and migration guide.

I added some very loud and ugly warning messages to the scripts but they should continue to work as-is for anyone relying on them.

I would suggest also moving this to our `pelias-deprecated` org.